### PR TITLE
feat: add Ghostty OpenCode split helpers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ findings.md
 progress.md
 task_plan.md
 .agent/
+.worktrees/
 
 # Backup Files
 *.backup_*

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1,6 +1,6 @@
 # Dotfiles Tool List
 
-**Last Updated**: 2026-02-06
+**Last Updated**: 2026-03-18
 
 ## Kubernetes & Container
 
@@ -77,6 +77,14 @@
   - Config: `zsh/tools/yazi.zsh`
   - Wrapper: `yy` (change directory on exit)
   - Managed symlink: `~/.config/yazi` -> `dotfiles/config/yazi`
+
+- **Ghostty**: Terminal emulator (external prerequisite for OCM helpers)
+  - Source: https://ghostty.org
+  - Config: `zsh/tools/ghostty.zsh`
+  - Provides:
+    - `ocm`: runs `opencode --continue` (continue previous session)
+    - `om`: runs `opencode` (fresh session)
+  - Behavior: Split focused pane, run OpenCode on left, `ocmonitor live --pick` on right
 
 ## Development Languages
 

--- a/zsh/rc.zsh
+++ b/zsh/rc.zsh
@@ -30,6 +30,7 @@ _load_tool_if_exists zoxide "${DOTFILES_ROOT}/zsh/tools/zoxide.zsh"
 _load_tool_if_exists lazygit "${DOTFILES_ROOT}/zsh/tools/lazygit.zsh"
 _load_tool_if_exists ghq "${DOTFILES_ROOT}/zsh/tools/ghq.zsh"
 _load_tool_if_exists yazi "${DOTFILES_ROOT}/zsh/tools/yazi.zsh"
+_load_tool_if_exists ghostty "${DOTFILES_ROOT}/zsh/tools/ghostty.zsh"
 
 # Load development tools (lazy loading)
 source "${DOTFILES_ROOT}/zsh/tools/dev/nvm.zsh"

--- a/zsh/tools/ghostty.zsh
+++ b/zsh/tools/ghostty.zsh
@@ -1,0 +1,73 @@
+#!/usr/bin/env zsh
+# ---
+# Tool: Ghostty
+# Source: https://ghostty.org/docs/features/applescript
+# Purpose: Ghostty pane workflow helpers for OpenCode
+# Updated: 2026-03-18
+# ---
+
+_ghostty_require_command() {
+  local cmd="$1"
+  command -v "$cmd" >/dev/null 2>&1 || {
+    print -u2 -- "ghostty workflow error: missing command '$cmd'"
+    return 1
+  }
+}
+
+_ghostty_quote_for_shell() {
+  printf '%q' "$1"
+}
+
+_ghostty_run_oc_workflow() {
+  local left_cmd="$1" left_line right_line quoted_cwd err_msg
+
+  [[ "$TERM_PROGRAM" != "Ghostty" ]] && {
+    print -u2 -- "ghostty workflow error: not running in Ghostty"
+    return 1
+  }
+
+  _ghostty_require_command osascript || return 1
+  _ghostty_require_command opencode || return 1
+  _ghostty_require_command ocmonitor || return 1
+  _ghostty_require_command ghostty || return 1
+
+  quoted_cwd="$(_ghostty_quote_for_shell "$PWD")"
+  left_line="cd -- ${quoted_cwd} && ${left_cmd}"$'\n'
+  right_line="cd -- ${quoted_cwd} && ocmonitor live --pick"$'\n'
+
+  if ! err_msg="$(osascript - "$left_line" "$right_line" <<'APPLESCRIPT'
+on run argv
+    set leftLine to item 1 of argv
+    set rightLine to item 2 of argv
+
+    tell application "Ghostty"
+        if not (running) then error "Ghostty is not running"
+        if (count of windows) is 0 then error "Ghostty has no open windows"
+
+        set frontWin to front window
+        set selectedTab to selected tab of frontWin
+        if selectedTab is missing value then error "No selected tab"
+        set originalTerm to focused terminal of selectedTab
+        if originalTerm is missing value then error "No focused terminal"
+
+        set rightTerm to split originalTerm direction right
+
+        input text leftLine to originalTerm
+        input text rightLine to rightTerm
+        focus originalTerm
+    end tell
+end run
+APPLESCRIPT
+  2>&1)"; then
+    print -u2 -- "ghostty workflow error: $err_msg"
+    return 1
+  fi
+}
+
+ocm() {
+  _ghostty_run_oc_workflow "opencode --continue"
+}
+
+om() {
+  _ghostty_run_oc_workflow "opencode"
+}


### PR DESCRIPTION
## Summary
- add Ghostty-backed `ocm` and `om` helpers that split the focused pane and start OpenCode plus `ocmonitor live --pick`
- load the new Ghostty helper module conditionally from `zsh/rc.zsh` without changing the existing `oc` alias
- document the Ghostty workflow commands in `docs/TOOLS.md`

## Verification
- `zsh -n zsh/rc.zsh && zsh -n zsh/tools/ghostty.zsh`
- `for i in {1..5}; do /usr/bin/time -p zsh -i -c exit 2>&1 | grep real; done`
- `zsh -c 'source zsh/rc.zsh; whence -w ocm om oc'`
- isolated `HOME=$TMP_HOME ./install.sh` then warm `HOME=$TMP_HOME make test`
- live Ghostty runs for `ocm` and `om` confirmed pane splits and focus restoration