### PR TITLE
feat: add OpenCode Java LSP launcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,11 @@ make uninstall
 exec zsh
 ```
 
+`make install` also manages OpenCode paths under `~/.config/opencode/`, including
+`opencode.json`, `commands/`, `agents/`, `oh-my-opencode-slim/`, and
+`bin/start_jdtls.sh`. If those paths already exist, the installer moves them into
+`~/.dotfiles_backup/...` before creating symlinks.
+
 See available commands: `make help`
 
 ## 🛠️ Main Tools

--- a/config/opencode/bin/start_jdtls.sh
+++ b/config/opencode/bin/start_jdtls.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+# ---
+# Tool: JDTLS (Java Development Tools Language Server)
+# Source: https://github.com/eclipse-jdtls/eclipse.jdt.ls
+# Purpose: Language server for Java development
+# Updated: 2026-03-19
+# ---
+
+set -euo pipefail
+
+# =============================================================================
+# Configuration with fallbacks
+# =============================================================================
+
+JDTLS_HOME="${JDTLS_HOME:-$HOME/.local/share/opencode/bin/jdtls}"
+JDTLS_LOMBOK_JAR="${JDTLS_LOMBOK_JAR:-$HOME/.lombok/lombok.jar}"
+
+# Cache directory for platform config (XDG_CACHE_HOME with fallback)
+JDTLS_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/jdtls"
+
+# =============================================================================
+# OS/Arch Detection
+# =============================================================================
+
+detect_platform_config() {
+  local os
+  local arch
+
+  case "$(uname -s)" in
+    Darwin)
+      os="mac"
+      ;;
+    Linux)
+      os="linux"
+      ;;
+    *)
+      echo "ERROR: Unsupported OS: $(uname -s)" >&2
+      exit 1
+      ;;
+  esac
+
+  case "$(uname -m)" in
+    x86_64)
+      arch=""
+      ;;
+    arm64|aarch64)
+      arch="_arm"
+      ;;
+    *)
+      echo "ERROR: Unsupported architecture: $(uname -m)" >&2
+      exit 1
+      ;;
+  esac
+
+  echo "config_${os}${arch}"
+}
+
+# =============================================================================
+# Validation Functions
+# =============================================================================
+
+validate_jdtls() {
+  if [[ ! -d "$JDTLS_HOME" ]]; then
+    echo "ERROR: JDTLS_HOME not found: $JDTLS_HOME" >&2
+    echo "Please install JDTLS or set JDTLS_HOME environment variable" >&2
+    exit 1
+  fi
+  echo "✓ JDTLS_HOME: $JDTLS_HOME" >&2
+}
+
+find_launcher_jar() {
+  local launcher_pattern="$JDTLS_HOME/plugins/org.eclipse.equinox.launcher_*.jar"
+  local launcher
+
+  # Use nullglob to get matching files
+  shopt -s nullglob
+  local launchers=($launcher_pattern)
+  shopt -u nullglob
+
+  if [[ ${#launchers[@]} -eq 0 ]]; then
+    echo "ERROR: Launcher jar not found: $launcher_pattern" >&2
+    echo "Please ensure JDTLS is properly installed" >&2
+    exit 1
+  fi
+
+  if [[ ${#launchers[@]} -gt 1 ]]; then
+    echo "ERROR: Multiple launcher jars found under $JDTLS_HOME/plugins" >&2
+    printf ' - %s\n' "${launchers[@]}" >&2
+    echo "Please clean up old JDTLS launcher jars so only one remains" >&2
+    exit 1
+  fi
+
+  # Take the first match (should be only one)
+  launcher="${launchers[0]}"
+  echo "$launcher"
+}
+
+find_platform_config() {
+  local platform_config="$JDTLS_HOME/$1"
+
+  if [[ ! -d "$platform_config" ]]; then
+    echo "ERROR: Platform config not found: $platform_config" >&2
+    echo "Please ensure JDTLS platform config is installed" >&2
+    exit 1
+  fi
+
+  # Return full path for fail-fast validation
+  echo "$platform_config"
+}
+
+validate_java() {
+  local java_cmd="$1"
+  local java_version
+
+  if ! command -v "$java_cmd" >/dev/null 2>&1; then
+    echo "ERROR: Java not found: $java_cmd" >&2
+    exit 1
+  fi
+
+  java_version=$("$java_cmd" -version 2>&1 | head -1 | awk -F '"' '{print $2}')
+
+  # Extract major version (e.g., "21.0.1" -> 21)
+  local major_version
+  major_version=$(echo "$java_version" | awk -F '.' '{print $1}')
+
+  if [[ -z "$major_version" || "$major_version" -lt 21 ]]; then
+    echo "ERROR: Java major version must be >= 21, found: $major_version ($java_version)" >&2
+    exit 1
+  fi
+
+  # Print validation to stderr, return only path via stdout
+  echo "✓ Java: $java_version" >&2
+  echo "$java_cmd"
+}
+
+validate_lombok() {
+  if [[ ! -f "$JDTLS_LOMBOK_JAR" ]]; then
+    echo "ERROR: Lombok jar not found: $JDTLS_LOMBOK_JAR" >&2
+    echo "Please install Lombok or set JDTLS_LOMBOK_JAR environment variable" >&2
+    exit 1
+  fi
+  echo "✓ Lombok: $JDTLS_LOMBOK_JAR" >&2
+}
+
+# =============================================================================
+# Workspace Generation
+# =============================================================================
+
+generate_workspace() {
+  # Generate unique workspace based on current directory hash
+  # Supports both Linux (md5sum) and macOS (md5 -q)
+  local pwd_hash
+  if command -v md5sum >/dev/null 2>&1; then
+    pwd_hash=$(echo "$PWD" | md5sum | awk '{print $1}')
+  elif command -v md5 >/dev/null 2>&1; then
+    pwd_hash=$(echo "$PWD" | md5 -q)
+  else
+    echo "ERROR: No md5 utility found (md5sum or md5)" >&2
+    exit 1
+  fi
+  echo "$JDTLS_CACHE_DIR/workspace-$pwd_hash"
+}
+
+# =============================================================================
+# Platform Config Caching
+# =============================================================================
+
+copy_platform_config_to_cache() {
+  local src_config="$1"
+  local cache_config="$JDTLS_CACHE_DIR/config"
+
+  # Create cache directory
+  mkdir -p "$JDTLS_CACHE_DIR"
+  mkdir -p "$cache_config"
+
+  # Remove old config to avoid stale files
+  rm -rf "$cache_config"/*
+
+  # Copy platform config to cache
+  cp -r "$src_config/"* "$cache_config/"
+
+  # Create marker file in writable config directory (with launcher jar path and mtime)
+  local launcher_mtime
+  local src_config_ini="$src_config/config.ini"
+  local config_mtime
+  launcher_mtime=$(stat -f %m "$LAUNCHER_JAR" 2>/dev/null || stat -c %Y "$LAUNCHER_JAR" 2>/dev/null)
+  config_mtime=$(stat -f %m "$src_config_ini" 2>/dev/null || stat -c %Y "$src_config_ini" 2>/dev/null)
+
+  printf '%s\n%s\n%s\n%s\n' \
+    "$LAUNCHER_JAR" \
+    "$launcher_mtime" \
+    "$src_config_ini" \
+    "$config_mtime" > "$cache_config/.opencode-jdtls-cache-marker"
+
+  echo "$cache_config"
+}
+
+should_refresh_cache() {
+  local cache_config="$JDTLS_CACHE_DIR/config"
+  local cache_marker="$cache_config/.opencode-jdtls-cache-marker"
+  local src_config="$1"
+  local src_config_ini="$src_config/config.ini"
+
+  # Check if marker exists
+  if [[ ! -f "$cache_marker" ]]; then
+    return 0  # No marker, need to copy
+  fi
+
+  # Check if config.ini exists (may have been deleted)
+  if [[ ! -f "$cache_config/config.ini" ]]; then
+    return 0  # Missing config.ini, need to refresh
+  fi
+
+  local cached_info
+  cached_info=$(cat "$cache_marker")
+
+  local launcher_mtime
+  local config_mtime
+  launcher_mtime=$(stat -f %m "$LAUNCHER_JAR" 2>/dev/null || stat -c %Y "$LAUNCHER_JAR" 2>/dev/null)
+  config_mtime=$(stat -f %m "$src_config_ini" 2>/dev/null || stat -c %Y "$src_config_ini" 2>/dev/null)
+
+  local expected_info
+  expected_info=$(printf '%s\n%s\n%s\n%s\n' \
+    "$LAUNCHER_JAR" \
+    "$launcher_mtime" \
+    "$src_config_ini" \
+    "$config_mtime")
+
+  if [[ "$cached_info" != "$expected_info" ]]; then
+    return 0  # Launcher changed, need to refresh
+  fi
+
+  return 1  # No refresh needed
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+main() {
+  echo "=== JDTLS Launcher ===" >&2
+  echo "" >&2
+
+  # Validate JDTLS installation
+  validate_jdtls
+
+  # Find launcher jar
+  LAUNCHER_JAR=$(find_launcher_jar)
+  echo "✓ Launcher: $LAUNCHER_JAR" >&2
+
+  # Detect and find platform config (fail-fast validation)
+  PLATFORM_CONFIG=$(detect_platform_config)
+  # find_platform_config validates and returns full path
+  config_path=$(find_platform_config "$PLATFORM_CONFIG")
+  echo "✓ Platform: $PLATFORM_CONFIG ($config_path)" >&2
+
+  # Check if platform config is writable (can modify)
+  if [[ -w "$config_path" ]]; then
+    echo "✓ Config: using $config_path (writable)" >&2
+    FINAL_CONFIG="$config_path"
+  else
+    # Need to copy to cache
+    if should_refresh_cache "$config_path"; then
+      echo "⚡ Copying platform config to cache..." >&2
+      FINAL_CONFIG=$(copy_platform_config_to_cache "$config_path")
+      echo "✓ Config: using $FINAL_CONFIG (cached)" >&2
+    else
+      echo "✓ Config: using cached config" >&2
+      FINAL_CONFIG="$JDTLS_CACHE_DIR/config"
+    fi
+  fi
+
+  # Validate Java
+  local java_cmd
+  if [[ -n "${JDTLS_JAVA_HOME:-}" ]]; then
+    java_cmd="$JDTLS_JAVA_HOME/bin/java"
+  elif [[ -n "${JAVA_HOME:-}" ]]; then
+    java_cmd="$JAVA_HOME/bin/java"
+  else
+    java_cmd="java"
+  fi
+  JAVA_PATH=$(validate_java "$java_cmd")
+
+  # Validate Lombok
+  validate_lombok
+
+  # Generate workspace
+  local workspace
+  workspace=$(generate_workspace)
+  mkdir -p "$workspace"
+  echo "✓ Workspace: $workspace" >&2
+
+  echo "" >&2
+  echo "=== Starting JDTLS ===" >&2
+
+  # Build JVM args
+  local jvm_args=(
+    "-javaagent:$JDTLS_LOMBOK_JAR"
+    "-XX:+UseParallelGC"
+    "-XX:+TieredCompilation"
+    "-XX:TieredStopAtLevel=1"
+    "-Xss4m"
+    "-Xmx2g"
+  )
+
+  # Execute JDTLS
+  exec "$JAVA_PATH" "${jvm_args[@]}" \
+    -jar "$LAUNCHER_JAR" \
+    -configuration "$FINAL_CONFIG" \
+    -data "$workspace"
+}
+
+main "$@"

--- a/config/opencode/opencode.json
+++ b/config/opencode/opencode.json
@@ -1,0 +1,278 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "plugin": [
+    "opencode-antigravity-auth@latest",
+    "@franlol/opencode-md-table-formatter@latest",
+    "oh-my-opencode-slim@latest",
+    "file:///Users/matt/code/github.com/shihyuho/opencode-command-inject"
+  ],
+  "default_agent": "Orchestrator",
+  "model": "openai/gpt-5.4",
+  "small_model": "minimax-coding-plan/MiniMax-M2.5",
+  "agent": {
+    "explore": {
+      "disable": true
+    },
+    "general": {
+      "disable": true
+    }
+  },
+  "mcp": {
+    "start_kapok": {
+      "enabled": false,
+      "type": "remote",
+      "url": "http://start-kapok.192.168.1.240.nip.io/mcp"
+    },
+    "kapok": {
+      "enabled": false,
+      "type": "remote",
+      "url": "http://kapok.192.168.1.240.nip.io/mcp"
+    },
+    "markitdown": {
+      "enabled": false,
+      "type": "local",
+      "command": [
+        "markitdown-mcp"
+      ]
+    },
+    "gh_grep": {
+      "enabled": false,
+      "type": "remote",
+      "url": "https://mcp.grep.app"
+    },
+    "chrome-devtools": {
+      "enabled": false,
+      "type": "local",
+      "command": [
+        "npx",
+        "-y",
+        "chrome-devtools-mcp@latest"
+      ]
+    }
+  },
+  "provider": {
+    "google": {
+      "models": {
+        "antigravity-gemini-3.1-pro": {
+          "name": "Gemini 3.1 Pro (Antigravity)",
+          "limit": {
+            "context": 1048576,
+            "output": 65535
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "variants": {
+            "low": {
+              "thinkingLevel": "low"
+            },
+            "high": {
+              "thinkingLevel": "high"
+            }
+          }
+        },
+        "antigravity-gemini-3-flash": {
+          "name": "Gemini 3 Flash (Antigravity)",
+          "limit": {
+            "context": 1048576,
+            "output": 65536
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "variants": {
+            "minimal": {
+              "thinkingLevel": "minimal"
+            },
+            "low": {
+              "thinkingLevel": "low"
+            },
+            "medium": {
+              "thinkingLevel": "medium"
+            },
+            "high": {
+              "thinkingLevel": "high"
+            }
+          }
+        },
+        "antigravity-claude-sonnet-4-5": {
+          "name": "Claude Sonnet 4.5 (Antigravity)",
+          "limit": {
+            "context": 200000,
+            "output": 64000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "antigravity-claude-sonnet-4-5-thinking": {
+          "name": "Claude Sonnet 4.5 Thinking (Antigravity)",
+          "limit": {
+            "context": 200000,
+            "output": 64000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "variants": {
+            "low": {
+              "thinkingConfig": {
+                "thinkingBudget": 8192
+              }
+            },
+            "max": {
+              "thinkingConfig": {
+                "thinkingBudget": 32768
+              }
+            }
+          }
+        },
+        "antigravity-claude-opus-4-5-thinking": {
+          "name": "Claude Opus 4.5 Thinking (Antigravity)",
+          "limit": {
+            "context": 200000,
+            "output": 64000
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          },
+          "variants": {
+            "low": {
+              "thinkingConfig": {
+                "thinkingBudget": 8192
+              }
+            },
+            "max": {
+              "thinkingConfig": {
+                "thinkingBudget": 32768
+              }
+            }
+          }
+        },
+        "gemini-2.5-flash": {
+          "name": "Gemini 2.5 Flash (Gemini CLI)",
+          "limit": {
+            "context": 1048576,
+            "output": 65536
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "gemini-2.5-pro": {
+          "name": "Gemini 2.5 Pro (Gemini CLI)",
+          "limit": {
+            "context": 1048576,
+            "output": 65536
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "gemini-3-flash-preview": {
+          "name": "Gemini 3 Flash Preview (Gemini CLI)",
+          "limit": {
+            "context": 1048576,
+            "output": 65536
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        },
+        "gemini-3.1-pro-preview": {
+          "name": "Gemini 3.1 Pro Preview (Gemini CLI)",
+          "limit": {
+            "context": 1048576,
+            "output": 65535
+          },
+          "modalities": {
+            "input": [
+              "text",
+              "image",
+              "pdf"
+            ],
+            "output": [
+              "text"
+            ]
+          }
+        }
+      }
+    }
+  },
+  "permission": {
+    "read": {
+      "~/.config/opencode/get-shit-done/*": "allow"
+    },
+    "external_directory": {
+      "~/.config/opencode/get-shit-done/*": "allow"
+    }
+  },
+  "lsp": {
+    "jdtls": {
+      "command": [
+        "/bin/sh",
+        "-lc",
+        "exec \"$HOME/.config/opencode/bin/start_jdtls.sh\""
+      ],
+      "extensions": [
+        ".java"
+      ]
+    }
+  }
+}

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -80,6 +80,101 @@ sdk list java
 sdk install java
 ```
 
+## OpenCode Configuration
+
+### Automatic Management
+
+The OpenCode configuration and launcher scripts are now managed by the dotfiles install flow:
+
+```bash
+make install  # Creates symlinks for OpenCode config
+```
+
+Managed symlinks include:
+- `~/.config/opencode/opencode.json` -> `dotfiles/config/opencode/opencode.json`
+- `~/.config/opencode/bin/start_jdtls.sh` -> `dotfiles/config/opencode/bin/start_jdtls.sh`
+- `~/.config/opencode/commands/` -> `dotfiles/config/opencode/commands/`
+- `~/.config/opencode/agents/` -> `dotfiles/config/opencode/agents/`
+- `~/.config/opencode/oh-my-opencode-slim/` -> `dotfiles/config/opencode/oh-my-opencode-slim/`
+
+### Migrating Existing OpenCode Config
+
+If you have an existing OpenCode configuration that you want to preserve:
+
+1. **Backup your existing config:**
+   ```bash
+   cp ~/.config/opencode/opencode.json ~/.config/opencode/opencode.json.backup
+   ```
+
+   If you already have any of these managed OpenCode paths, `make install` will move the existing files or directories into `~/.dotfiles_backup/...` before creating symlinks:
+
+   - `~/.config/opencode/opencode.json`
+   - `~/.config/opencode/commands/`
+   - `~/.config/opencode/agents/`
+   - `~/.config/opencode/oh-my-opencode-slim/`
+   - `~/.config/opencode/bin/start_jdtls.sh`
+
+2. **Review the managed config:**
+   ```bash
+   cat config/opencode/opencode.json
+   ```
+
+3. **Merge settings manually into the repo copy**: Update `config/opencode/opencode.json` in this repository, not `~/.config/opencode/opencode.json`, because `make install` will replace the home-directory file with a symlink to the repo copy. The managed `opencode.json` includes JDTLS LSP configuration. If you have custom settings, merge them carefully - the managed file contains:
+   - Plugin list
+   - Default agent and model settings
+   - MCP server configurations
+   - Provider definitions
+   - Permission settings
+   - **LSP configuration for JDTLS** (at the end under `lsp.jdtls`)
+
+   If the managed plugin list includes local `file://` plugins, make sure those paths exist on the current machine or update the plugin entry after installation.
+
+4. **Reinstall to apply changes:**
+   ```bash
+   make install
+   ```
+
+### JDTLS / Lombok Prerequisites
+
+JDTLS (Java Development Tools Language Server) requires:
+
+1. **Java 21+**: Ensure you have Java 21 or later installed:
+   ```bash
+   java -version  # Should show 21+
+   ```
+
+2. **JDTLS Installation**: Download and install JDTLS from:
+   - Stable releases: https://download.eclipse.org/jdtls/milestones/
+   - Latest builds: https://download.eclipse.org/jdtls/snapshots/
+   - Source and build instructions: https://github.com/eclipse-jdtls/eclipse.jdt.ls
+   - Install the extracted JDTLS distribution under `~/.local/share/opencode/bin/jdtls`, or set `JDTLS_HOME` to the installed location
+
+3. **Lombok JAR**: Ensure Lombok jar exists at default location or set override:
+   - Default: `~/.lombok/lombok.jar`
+   - Override: `export JDTLS_LOMBOK_JAR=/path/to/lombok.jar`
+
+If Java is older than 21, the launcher will fail with an error like:
+
+```text
+ERROR: Java major version must be >= 21
+```
+
+### Override Environment Variables
+
+You can override default paths by setting these environment variables in your `~/.secrets` or shell profile:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `JDTLS_HOME` | `$HOME/.local/share/opencode/bin/jdtls` | JDTLS installation directory |
+| `JDTLS_JAVA_HOME` | `$JAVA_HOME` or system `java` | Java home for JDTLS |
+| `JDTLS_LOMBOK_JAR` | `$HOME/.lombok/lombok.jar` | Lombok jar path |
+
+Example in `~/.secrets`:
+```bash
+export JDTLS_HOME="/opt/jdtls"
+export JDTLS_LOMBOK_JAR="$HOME/.local/lib/lombok.jar"
+```
+
 ## Verify Installation
 
 ```bash
@@ -121,6 +216,14 @@ brew doctor
 
 ```bash
 make measure-startup
+```
+
+### JDTLS cache looks stale
+
+If JDTLS has been upgraded or the cached writable config looks suspect, remove the cache and let the launcher rebuild it:
+
+```bash
+rm -rf "${XDG_CACHE_HOME:-$HOME/.cache}/jdtls"
 ```
 
 ## More Information

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -82,6 +82,17 @@
   - Command: `ocmonitor live --pick`
   - Notes: Opens the ocmonitor live picker directly; `oc` remains `opencode --continue`
 
+- **OpenCode Java LSP (JDTLS)**: Language Server Protocol for Java
+  - Launcher: `config/opencode/bin/start_jdtls.sh`
+  - Managed symlink: `~/.config/opencode/bin/start_jdtls.sh` -> `dotfiles/config/opencode/bin/start_jdtls.sh`
+  - JDTLS distribution: install separately under `JDTLS_HOME` (default: `$HOME/.local/share/opencode/bin/jdtls`)
+  - Environment Variables:
+    - `JDTLS_HOME`: JDTLS installation directory (default: `$HOME/.local/share/opencode/bin/jdtls`)
+    - `JDTLS_JAVA_HOME`: Java home for JDTLS (default: uses `JAVA_HOME` or system `java`)
+    - `JDTLS_LOMBOK_JAR`: Path to Lombok jar (default: `$HOME/.lombok/lombok.jar`)
+  - Requirements: Java 21+
+  - Notes: Uses Lombok for annotation processing; ensure `~/.lombok/lombok.jar` exists or set `JDTLS_LOMBOK_JAR`
+
 ## Development Languages
 
 - **Go**: Go programming language

--- a/install.sh
+++ b/install.sh
@@ -60,13 +60,29 @@ link_file "$DOTFILES_ROOT/external/kubectl_aliases" "$HOME/.kubectl_aliases"
 link_file "$DOTFILES_ROOT/external/kube-ps1.sh" "$HOME/.kube-ps1.sh"
 
 echo ""
-echo "📂 Linking misc configurations..."
-link_file "$DOTFILES_ROOT/config/gemini/GEMINI.md" "$HOME/.gemini/GEMINI.md"
-link_file "$DOTFILES_ROOT/config/yazi" "$HOME/.config/yazi"
-link_file "$DOTFILES_ROOT/config/ghostty" "$HOME/.config/ghostty"
+echo "📂 Linking OpenCode configurations..."
+# Link JDTLS launcher first (required by opencode.json)
+link_file "$DOTFILES_ROOT/config/opencode/bin/start_jdtls.sh" "$HOME/.config/opencode/bin/start_jdtls.sh"
+# Link opencode.json last (depends on launcher)
+link_file "$DOTFILES_ROOT/config/opencode/opencode.json" "$HOME/.config/opencode/opencode.json"
 link_file "$DOTFILES_ROOT/config/opencode/commands" "$HOME/.config/opencode/commands"
 link_file "$DOTFILES_ROOT/config/opencode/agents" "$HOME/.config/opencode/agents"
 link_file "$DOTFILES_ROOT/config/opencode/oh-my-opencode-slim" "$HOME/.config/opencode/oh-my-opencode-slim"
+
+echo ""
+echo "📂 Linking Gemini configurations..."
+link_file "$DOTFILES_ROOT/config/gemini/GEMINI.md" "$HOME/.gemini/GEMINI.md"
+
+echo ""
+echo "📂 Linking Yazi configurations..."
+link_file "$DOTFILES_ROOT/config/yazi" "$HOME/.config/yazi"
+
+echo ""
+echo "📂 Linking Ghostty configurations..."
+link_file "$DOTFILES_ROOT/config/ghostty" "$HOME/.config/ghostty"
+
+echo ""
+echo "📂 Linking misc configurations..."
 link_file "$DOTFILES_ROOT/misc/tmux.conf" "$HOME/.tmux.conf"
 link_file "$DOTFILES_ROOT/misc/vimrc" "$HOME/.vimrc"
 link_file "$DOTFILES_ROOT/misc/editorconfig" "$HOME/.editorconfig"

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -68,13 +68,32 @@ unlink_file "$DOTFILES_ROOT/external/kubectl_aliases" "$HOME/.kubectl_aliases"
 unlink_file "$DOTFILES_ROOT/external/kube-ps1.sh" "$HOME/.kube-ps1.sh"
 
 echo ""
+echo "📂 Removing OpenCode configuration links..."
+
+# Unlink opencode.json first (depends on launcher)
+unlink_file "$DOTFILES_ROOT/config/opencode/opencode.json" "$HOME/.config/opencode/opencode.json"
+
+# Always process launcher through normal unlink/restore flow first.
+unlink_file "$DOTFILES_ROOT/config/opencode/bin/start_jdtls.sh" "$HOME/.config/opencode/bin/start_jdtls.sh"
+
+# Warn only if the restored/current config still references the launcher but no launcher exists now.
+if [[ -f "$HOME/.config/opencode/opencode.json" ]] && grep -q "start_jdtls.sh" "$HOME/.config/opencode/opencode.json" 2>/dev/null; then
+  if [[ ! -e "$HOME/.config/opencode/bin/start_jdtls.sh" && ! -L "$HOME/.config/opencode/bin/start_jdtls.sh" ]]; then
+    echo "⚠️  WARNING: $HOME/.config/opencode/opencode.json still references JDTLS launcher."
+    echo "   No launcher was restored at $HOME/.config/opencode/bin/start_jdtls.sh. Please restore or recreate it manually."
+  fi
+fi
+
+# Other OpenCode configurations
+unlink_file "$DOTFILES_ROOT/config/opencode/commands" "$HOME/.config/opencode/commands"
+unlink_file "$DOTFILES_ROOT/config/opencode/agents" "$HOME/.config/opencode/agents"
+unlink_file "$DOTFILES_ROOT/config/opencode/oh-my-opencode-slim" "$HOME/.config/opencode/oh-my-opencode-slim"
+
+echo ""
 echo "📂 Removing misc configuration links..."
 unlink_file "$DOTFILES_ROOT/config/gemini/GEMINI.md" "$HOME/.gemini/GEMINI.md"
 unlink_file "$DOTFILES_ROOT/config/yazi" "$HOME/.config/yazi"
 unlink_file "$DOTFILES_ROOT/config/ghostty" "$HOME/.config/ghostty"
-unlink_file "$DOTFILES_ROOT/config/opencode/commands" "$HOME/.config/opencode/commands"
-unlink_file "$DOTFILES_ROOT/config/opencode/agents" "$HOME/.config/opencode/agents"
-unlink_file "$DOTFILES_ROOT/config/opencode/oh-my-opencode-slim" "$HOME/.config/opencode/oh-my-opencode-slim"
 unlink_file "$DOTFILES_ROOT/misc/tmux.conf" "$HOME/.tmux.conf"
 unlink_file "$DOTFILES_ROOT/misc/vimrc" "$HOME/.vimrc"
 unlink_file "$DOTFILES_ROOT/misc/editorconfig" "$HOME/.editorconfig"


### PR DESCRIPTION
## Summary
- add a repo-managed OpenCode JDTLS launcher with Java 21, Lombok, workspace isolation, and cache refresh handling
- manage `opencode.json` and `start_jdtls.sh` through the dotfiles install/uninstall flow with backup-aware uninstall behavior
- document the OpenCode migration flow, JDTLS prerequisites, and launcher overrides in the setup docs

## Test Plan
- [x] `zsh -n ~/.zshrc`
- [x] `for i in {1..5}; do /usr/bin/time -p zsh -i -c exit 2>&1 | grep real; done`
- [x] `zsh -i -c exit`
- [x] `ls -la ~ | grep "dotfiles"`
- [x] `make test-keybindings`
- [x] `DOTFILES_ROOT=/Users/matt/code/github.com/shihyuho/dotfiles ./.agents/skills/dotfiles-manager/scripts/test.sh`
- [x] `JDTLS_HOME=/nonexistent config/opencode/bin/start_jdtls.sh >/tmp/jdtls.out 2>/tmp/jdtls.err || true; test ! -s /tmp/jdtls.out && grep -q "JDTLS_HOME not found" /tmp/jdtls.err`